### PR TITLE
update dwm fibonacci diff url

### DIFF
--- a/modules/dwm/manifests/init.pp
+++ b/modules/dwm/manifests/init.pp
@@ -40,7 +40,7 @@ class fetch_patches {
     require clone_dwm_repo
     require refresh_dwm_repo
     wget::fetch { 'download dwm fibonacci patch':
-        source => 'http://dwm.suckless.org/patches/dwm-5.8.2-fibonacci.diff',
+        source => 'http://dwm.suckless.org/patches/dwm-fibonacci-5.8.2.diff',
 	destination => "/home/${::nonroot_username}/.dwm/fibonacci.diff",
 	timeout => 0,
 	verbose => false,


### PR DESCRIPTION
fixes

```
Notice: /Stage[main]/Fetch_patches/Wget::Fetch[download dwm fibonacci
patch]/Exec[wget-download dwm fibonacci patch]/returns: 2016-07-17
06:47:03 ERROR 404: Not Found.
Error: wget --no-verbose
--output-document="/home/nonroot/.dwm/fibonacci.diff"
"http://dwm.suckless.org/patches/dwm-5.8.2-fibonacci.diff" returned 8
instead of one of [0]
Error: /Stage[main]/Fetch_patches/Wget::Fetch[download dwm fibonacci
patch]/Exec[wget-download dwm fibonacci patch]/returns: change from
notrun to 0 failed: wget --no-verbose
--output-document="/home/nonroot/.dwm/fibonacci.diff"
"http://dwm.suckless.org/patches/dwm-5.8.2-fibonacci.diff" returned 8
instead of one of [0]
```
