### PR TITLE
update gapless grid url

### DIFF
--- a/modules/dwm/manifests/init.pp
+++ b/modules/dwm/manifests/init.pp
@@ -47,7 +47,7 @@ class fetch_patches {
 	execuser => $::nonroot_username,
     }
     wget::fetch { 'download dwm gapless_grid patch':
-        source => 'http://dwm.suckless.org/patches/dwm-6.1-gaplessgrid.diff',
+        source => 'http://dwm.suckless.org/patches/dwm-gaplessgrid-6.1.diff',
 	destination => "/home/${::nonroot_username}/.dwm/gapless_grid.diff",
 	timeout => 0,
 	verbose => false,


### PR DESCRIPTION
```
Debug: Exec[wget-download dwm gapless_grid patch](provider=posix): Executing 'wget --no-verbose --output-document="/home/nonroot/.dwm/gapless_grid.diff" "http://dwm.suckless.org/patches/dwm-6.1-gaplessgrid.diff"'
Debug: Executing with uid=nonroot: 'wget --no-verbose --output-document="/home/nonroot/.dwm/gapless_grid.diff" "http://dwm.suckless.org/patches/dwm-6.1-gaplessgrid.diff"'
Notice: /Stage[main]/Fetch_patches/Wget::Fetch[download dwm gapless_grid patch]/Exec[wget-download dwm gapless_grid patch]/returns: http://dwm.suckless.org/patches/dwm-6.1-gaplessgrid.diff:
Notice: /Stage[main]/Fetch_patches/Wget::Fetch[download dwm gapless_grid patch]/Exec[wget-download dwm gapless_grid patch]/returns: 2016-07-21 06:12:35 ERROR 404: Not Found.
```
