### PR TITLE
skip after mesh hooks in test

### DIFF
--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
         spawn_server_command = [
             'raptiformica', 'spawn', '--server-type',
             server_type, '--compute-type', compute_type,
-            '--cache-dir', cache_dir
+            '--cache-dir', cache_dir, '--no-after-mesh'
         ]
         check_call(spawn_server_command)
 


### PR DESCRIPTION
should speed up the integration tests somewhat, not bootstrapping clusters there anyway